### PR TITLE
Fix luaL_Buffer usage

### DIFF
--- a/tests/luaL_buffaddr_test.c
+++ b/tests/luaL_buffaddr_test.c
@@ -14,11 +14,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return 0;
 
 	luaL_Buffer buf;
-	luaL_buffinitsize(L, &buf, size);
-	luaL_addlstring(&buf, (const char *)data, size);
+	char *s = luaL_buffinitsize(L, &buf, size);
+	memcpy(s, data, size);
+	luaL_pushresultsize(&buf, size);
 	if (luaL_buffaddr(&buf) == NULL)
 		return 0;
-	luaL_pushresultsize(&buf, size);
 
 	lua_settop(L, 0);
 	lua_close(L);

--- a/tests/luaL_bufflen_test.c
+++ b/tests/luaL_bufflen_test.c
@@ -18,12 +18,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return -1;
 
 	luaL_Buffer buf;
-	luaL_buffinitsize(L, &buf, size);
-	luaL_addlstring(&buf, (const char *)data, size);
-
-	assert(luaL_bufflen(&buf) == size);
+	char *s = luaL_buffinitsize(L, &buf, size);
+	memcpy(s, data, size);
 
 	luaL_pushresultsize(&buf, size);
+
+	assert(luaL_bufflen(&buf) == size);
 
 	lua_settop(L, 0);
 	lua_close(L);

--- a/tests/luaL_buffsub_test.c
+++ b/tests/luaL_buffsub_test.c
@@ -20,8 +20,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return 0;
 
 	luaL_Buffer buf;
-	luaL_buffinitsize(L, &buf, size);
-	luaL_addlstring(&buf, (const char *)data, size);
+	char *s = luaL_buffinitsize(L, &buf, size);
+	memcpy(s, data, size);
+	luaL_pushresultsize(&buf, size);
 	/* TODO: Use FDP. */
 	luaL_buffsub(&buf, 1);
 


### PR DESCRIPTION
According to Lua Reference [1] one should copy the string in already allocated space by luaL_buffinitsize

[1] https://www.lua.org/manual/5.3/manual.html#luaL_Buffer