### PR TITLE
cmake: enable Lua compile options

### DIFF
--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -4,7 +4,7 @@ macro(build_lua LUA_VERSION)
 
     set(LUA_PATCH_PATH ${PROJECT_SOURCE_DIR}/patches/puc-rio-lua.patch)
 
-    set(CFLAGS "-fsanitize=fuzzer-no-link")
+    set(CFLAGS "-DLUAI_ASSERT=1 -DLUA_USE_APICHECK=1 -fsanitize=fuzzer-no-link")
     set(LDFLAGS "-fsanitize=fuzzer-no-link")
 
     if (ENABLE_ASAN)

--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -2,7 +2,7 @@ macro(build_luajit LJ_VERSION)
     set(LJ_SOURCE_DIR ${PROJECT_BINARY_DIR}/luajit-${LJ_VERSION}/source)
     set(LJ_BINARY_DIR ${PROJECT_BINARY_DIR}/luajit-${LJ_VERSION}/work)
 
-    set(CFLAGS "-fsanitize=fuzzer-no-link")
+    set(CFLAGS "-DLUAI_ASSERT=1 -DLUA_USE_APICHECK=1 -fsanitize=fuzzer-no-link")
     set(LDFLAGS "-fsanitize=fuzzer-no-link")
 
     if (ENABLE_ASAN)


### PR DESCRIPTION
```
cmake: enable additional Lua compile options
    
- LUAI_ASSERT and LUA_USE_ASSERT turns on all assertions inside Lua.
- LUA_USE_APICHECK turns on several consistency checks on the C API.
```