### PR TITLE
Fix using of unitialized value.

### DIFF
--- a/tests/lua_load_test.c
+++ b/tests/lua_load_test.c
@@ -22,7 +22,7 @@ Reader(lua_State *L, void *data, size_t *size)
 	free(buf);
 
 	buf = malloc(test_data->sz);
-	fread(buf, test_data->sz, 1, test_data->fd);
+	*size = fread(buf, test_data->sz, 1, test_data->fd);
 
 	return buf;
 }


### PR DESCRIPTION
Hi! I've found an error in fuzz target `lua_load_test`.
The `size` variable was declared in `luaZ_fill`, but not initialized. Later it is passed to `Reader` function, which is declared in fuzz target code. The `size` variable has to be filled in `Reader`.

Because `size` was not initialized, but was later used, the UB can occur later in `luaZ_fill`.
Fixed it with setting `size` to the result of `fread`.