### PR TITLE
tests: fix of heap buffer overflow

### DIFF
--- a/tests/luaL_addgsub_test.cc
+++ b/tests/luaL_addgsub_test.cc
@@ -27,16 +27,15 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return 0;
 
 	luaL_Buffer buf;
-	size_t buf_size = fdp.ConsumeIntegralInRange<int8_t>(0, INT8_MAX);
+	auto str = fdp.ConsumeRandomLengthString(size);
+	size_t buf_size = str.length();
 	char *s = luaL_buffinitsize(L, &buf, buf_size);
-	auto str = fdp.ConsumeRandomLengthString(buf_size);
 	memcpy(s, str.c_str(), buf_size);
 	luaL_pushresultsize(&buf, buf_size);
 
-	size_t max_length = fdp.ConsumeIntegralInRange<size_t>(1, INT8_MAX);
-	auto str1 = fdp.ConsumeRandomLengthString(max_length);
-	auto str2 = fdp.ConsumeRandomLengthString(max_length);
-	auto str3 = fdp.ConsumeRandomLengthString(max_length);
+	auto str1 = fdp.ConsumeRandomLengthString(size);
+	auto str2 = fdp.ConsumeRandomLengthString(size);
+	auto str3 = fdp.ConsumeRandomLengthString(size);
 	const char *c_str1 = str1.c_str();
 	const char *c_str2 = str2.c_str();
 	const char *c_str3 = str3.c_str();

--- a/tests/luaL_buffsub_test.cc
+++ b/tests/luaL_buffsub_test.cc
@@ -28,9 +28,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 		return 0;
 
 	luaL_Buffer buf;
-	size_t buf_size = fdp.ConsumeIntegralInRange<int8_t>(0, INT8_MAX);
+	auto str = fdp.ConsumeRandomLengthString(size);
+	size_t buf_size = str.length() + 1;
 	char *s = luaL_buffinitsize(L, &buf, buf_size);
-	auto str = fdp.ConsumeRandomLengthString(buf_size);
 	memcpy(s, str.c_str(), buf_size);
 	luaL_pushresultsize(&buf, buf_size);
 	int8_t n = fdp.ConsumeIntegralInRange<int8_t>(0, buf_size);

--- a/tests/luaL_gsub_test.cc
+++ b/tests/luaL_gsub_test.cc
@@ -26,10 +26,9 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if (L == NULL)
 		return 0;
 
-	size_t max_length = fdp.ConsumeIntegralInRange<size_t>(1, INT8_MAX);
-	auto str1 = fdp.ConsumeRandomLengthString(max_length);
-	auto str2 = fdp.ConsumeRandomLengthString(max_length);
-	auto str3 = fdp.ConsumeRandomLengthString(max_length);
+	auto str1 = fdp.ConsumeRandomLengthString(size);
+	auto str2 = fdp.ConsumeRandomLengthString(size);
+	auto str3 = fdp.ConsumeRandomLengthString(size);
 	const char *c_str1 = str1.c_str();
 	const char *c_str2 = str2.c_str();
 	const char *c_str3 = str3.c_str();


### PR DESCRIPTION
The heap buffer overflow occurred because of `buf_size` value, which could be greater than the original string size. FDP gives the random length substring constrained by max length parameter and original string size.

Fixed with passing original string size as the max size paramter to FDP. Removed getting random `buf_size`, because FDP already returns random length string.