### PR TITLE
cmake: build and create tests using a common function

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,12 +43,13 @@ function(create_test)
     FUZZ
     ""
     "FILENAME"
-    ""
+    "SOURCES;LIBRARIES"
     ${ARGN}
   )
   get_filename_component(test_name ${FUZZ_FILENAME} NAME_WE)
-  add_executable(${test_name} ${FUZZ_FILENAME})
-  target_link_libraries(${test_name} PUBLIC fuzzer_config ${LUA_LIBRARIES} ${LDFLAGS})
+  add_executable(${test_name} ${FUZZ_SOURCES})
+
+  target_link_libraries(${test_name} PUBLIC fuzzer_config ${FUZZ_LIBRARIES} ${LUA_LIBRARIES} ${LDFLAGS})
   target_include_directories(${test_name} PRIVATE ${LUA_INCLUDE_DIR})
   target_compile_options(${test_name} PRIVATE -Wall -Wextra -Wpedantic -Wno-unused-parameter -g)
   add_dependencies(${test_name} ${LUA_TARGET})
@@ -91,7 +92,9 @@ foreach(filename ${tests})
   if (USE_LUAJIT AND (${test_name} IN_LIST LUAJIT_BLACKLIST_TESTS))
     continue()
   endif ()
-  create_test(FILENAME ${filename})
+  create_test(FILENAME ${test_name}
+              SOURCES ${filename}
+              LIBRARIES "")
 endforeach()
 
 include(ProtobufMutator)

--- a/tests/luaL_loadbuffer_proto/CMakeLists.txt
+++ b/tests/luaL_loadbuffer_proto/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(test_name luaL_loadbuffer_proto_test)
 
-add_executable(${test_name}
-               luaL_loadbuffer_proto_test.cc
-               serializer.cc)
-
 add_library(lua_grammar-proto)
 
 foreach(lib ${LPM_LIBRARIES})
@@ -17,33 +13,9 @@ protobuf_generate(LANGUAGE cpp
 target_link_libraries(lua_grammar-proto
                       ${PROTOBUF_LIBRARIES})
 
+create_test(FILENAME ${test_name}
+            SOURCES luaL_loadbuffer_proto_test.cc serializer.cc
+            LIBRARIES lua_grammar-proto ${LPM_LIBRARIES})
+
 target_include_directories(${test_name} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${LUA_INCLUDE_DIR})
-
-target_link_libraries(${test_name}
-                      PUBLIC
-                      lua_grammar-proto
-                      ${LPM_LIBRARIES}
-                      ${LUA_LIBRARIES}
-                      ${LDFLAGS}
-                      fuzzer_config)
-
-add_dependencies(${test_name}
-                 ${LUA_TARGET}
-                 ${LPM_LIBRARIES}
-                 lua_grammar-proto)
-
-string(REPLACE "_test" "" test_prefix ${test_name})
-add_test(NAME ${test_name}
-         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_name}
-                 -use_value_profile=1
-                 -report_slow_units=5
-                 -reload=1
-                 -reduce_inputs=1
-                 -print_pcs=1
-                 -print_final_stats=1
-                 -mutate_depth=20
-                 -runs=5
-                 -artifact_prefix=${test_name}_
-                 -dict=${PROJECT_SOURCE_DIR}/corpus/${test_prefix}.dict
-                 ${PROJECT_SOURCE_DIR}/corpus/${test_prefix}
-)
+add_dependencies(${test_name} ${LPM_LIBRARIES} lua_grammar-proto)


### PR DESCRIPTION
luaL_loadbuffer_proto build infrastructure shares test options, compiler flags, linker flags with other tests, but code for tests in `tests/` and in `tests/luaL_loadbuffer_proto/` is different.

This is error-prone and forces always remember to apply fixes in both places (see commits: 70a671d5 ("cmake: add underscore to artifact_prefix option"), 121fd6f3 ("tests: reduce a number of test runs"), 70a671d5 ("cmake: add underscore to artifact_prefix option")) and even leads to bugs, see commit 58f4a5b4 ("tests: fix passing LDFLAGS to luaL_loadbuffer_proto").