### PR TITLE
tests: pass text chunks, not a binary chunks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,10 +86,18 @@ list(APPEND LUAJIT_BLACKLIST_TESTS "luaL_buffaddr_test")
 list(APPEND LUAJIT_BLACKLIST_TESTS "lua_load_test")
 list(APPEND LUAJIT_BLACKLIST_TESTS "lua_stringtonumber_test")
 
+# https://github.com/ligurio/lua-c-api-tests/issues/19
+list(APPEND BLACKLIST_TESTS "luaL_dostring")
+list(APPEND BLACKLIST_TESTS "luaL_loadbuffer")
+list(APPEND BLACKLIST_TESTS "luaL_loadstring")
+
 file(GLOB tests LIST_DIRECTORIES false ${CMAKE_CURRENT_SOURCE_DIR} *.c *.cc)
 foreach(filename ${tests})
   get_filename_component(test_name ${filename} NAME_WE)
   if (USE_LUAJIT AND (${test_name} IN_LIST LUAJIT_BLACKLIST_TESTS))
+    continue()
+  endif ()
+  if ((${test_name} IN_LIST BLACKLIST_TESTS))
     continue()
   endif ()
   create_test(FILENAME ${test_name}

--- a/tests/luaL_loadbufferx_test.c
+++ b/tests/luaL_loadbufferx_test.c
@@ -24,7 +24,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	luaL_dostring(L, "jit.opt.start('callunroll=1')");
 #endif /* LUAJIT */
 
-	const char *mode = "bt";
+	const char *mode = "t";
 	int res = luaL_loadbufferx(L, (const char *)data, size, "fuzz", mode);
 	if (res != LUA_OK)
 		return 0;

--- a/tests/lua_load_test.c
+++ b/tests/lua_load_test.c
@@ -43,7 +43,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	test_data.fd = fd;
 	test_data.sz = 1;
 
-	const char *mode = "bt";
+	const char *mode = "t";
 	int res = lua_load(L, Reader, &test_data, "libFuzzer", mode);
 	if (res != LUA_OK)
 		return 0;


### PR DESCRIPTION
Functions `lua_load` and `luaL_loadbufferx` allows passing a string with mode that controls whether the chunk can be text or binary (that is, a precompiled chunk). It may be the string "b" (only binary chunks), "t" (only text chunks), or "bt" (both binary and text). The default is "bt". Fuzzing bytecode is prohibited, see [1] and Lua manual [2]:

> Lua does not check the consistency of binary chunks. Maliciously
> crafted binary chunks can crash the interpreter.

so mode "b" has been removed.

Functions `luaL_loadstring` and `luaL_loadbuffer` sets mode to `NULL`, it is equivalent to the string "bt". Tests for these functions should not use byte-level mutations, so these tests temporarily disabled.

1. https://github.com/LuaJIT/LuaJIT/issues/847
2. https://www.lua.org/manual/5.3/manual.html#lua_load

Closes #19