### PR TITLE
cmake: fix macros that enables assertions in LuaJIT

### DIFF
--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -2,7 +2,7 @@ macro(build_luajit LJ_VERSION)
     set(LJ_SOURCE_DIR ${PROJECT_BINARY_DIR}/luajit-${LJ_VERSION}/source)
     set(LJ_BINARY_DIR ${PROJECT_BINARY_DIR}/luajit-${LJ_VERSION}/work)
 
-    set(CFLAGS "-DLUAI_ASSERT=1 -DLUA_USE_APICHECK=1 -fsanitize=fuzzer-no-link")
+    set(CFLAGS "-DLUA_USE_ASSERT=1 -DLUA_USE_APICHECK=1 -fsanitize=fuzzer-no-link")
     set(LDFLAGS "-fsanitize=fuzzer-no-link")
 
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
Commit 0839df9c ("cmake: enable additional Lua compile options") enables macros `LUAI_ASSERT` in LuaJIT by mistake. The same macros for LuaJIT has another name - `LUA_USE_ASSERT`. Patch fixes that.