### PR TITLE
cmake: support AddressSanitizer in LuaJIT

### DIFF
--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -5,6 +5,8 @@ macro(build_luajit LJ_VERSION)
     set(CFLAGS "-DLUA_USE_ASSERT=1 -DLUA_USE_APICHECK=1 -fsanitize=fuzzer-no-link")
     set(LDFLAGS "-fsanitize=fuzzer-no-link")
 
+    set(LUAJIT_PATCH_PATH ${PROJECT_SOURCE_DIR}/patches/luajit-v2.1.patch)
+
     if (CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(CFLAGS "${CFLAGS} ${CMAKE_C_FLAGS_DEBUG}")
         set(LDFLAGS "${LDFLAGS} ${CMAKE_C_FLAGS_DEBUG}")
@@ -12,6 +14,8 @@ macro(build_luajit LJ_VERSION)
 
     if (ENABLE_ASAN)
         set(CFLAGS "${CFLAGS} -fsanitize=address")
+        set(CFLAGS "${CFLAGS} -DLUAJIT_USE_ASAN")
+        set(CFLAGS "${CFLAGS} -DLUAJIT_USE_SYSMALLOC=1")
         set(LDFLAGS "${LDFLAGS} -fsanitize=address")
     endif (ENABLE_ASAN)
 
@@ -40,6 +44,7 @@ macro(build_luajit LJ_VERSION)
         TMP_DIR ${LJ_BINARY_DIR}/tmp
         STAMP_DIR ${LJ_BINARY_DIR}/stamp
 
+        PATCH_COMMAND cd <SOURCE_DIR> && patch -p1 -i ${LUAJIT_PATCH_PATH}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND cd <SOURCE_DIR> && make -j CC=${CMAKE_C_COMPILER} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS}
         INSTALL_COMMAND ""

--- a/patches/luajit-v2.1.patch
+++ b/patches/luajit-v2.1.patch
@@ -1,0 +1,35 @@
+diff --git a/src/host/buildvm.c b/src/host/buildvm.c
+index 9ee47ada..0cb6be1b 100644
+--- a/src/host/buildvm.c
++++ b/src/host/buildvm.c
+@@ -35,6 +35,10 @@
+ #include <io.h>
+ #endif
+ 
++#if LUAJIT_USE_ASAN
++int __lsan_is_turned_off() { return 1; } /* leaks are ok */
++#endif
++
+ /* ------------------------------------------------------------------------ */
+ 
+ /* DynASM glue definitions. */
+diff --git a/src/lj_str.c b/src/lj_str.c
+index a5282da6..f31172bb 100644
+--- a/src/lj_str.c
++++ b/src/lj_str.c
+@@ -13,6 +13,15 @@
+ #include "lj_char.h"
+ #include "lj_prng.h"
+ 
++#if LUAJIT_USE_ASAN
++/* These functions may read past a buffer end, that's ok. */
++GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
++  __attribute__((no_sanitize_address));
++
++int32_t LJ_FASTCALL lj_str_cmp(GCstr *a, GCstr *b)
++  __attribute__((no_sanitize_address));
++#endif /* LUAJIT_USE_ASAN */
++
+ /* -- String helpers ------------------------------------------------------ */
+ 
+ /* Ordered compare of strings. Assumes string data is 4-byte aligned. */


### PR DESCRIPTION
The patch turns off leak checks in buildvm, because it is a part of infrastructure and leaks there are not interesting, and disables Address Sanitizer for two functions: `lj_str_new` and `lj_str_cmp`, because these functions may read past a buffer end, that's ok.

With CMake option ENABLE_ASAN LuaJIT will use system malloc (`-DLUAJIT_USE_SYSMALLOC=1`), because memory allocator used by LuaJIT is not instrumented by ASAN.

Fixes #22