### PR TITLE
Collect and print LuaJIT metrics

### DIFF
--- a/tests/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc
+++ b/tests/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc
@@ -6,6 +6,8 @@ extern "C"
 #ifdef LUAJIT
 #include "luajit.h"
 #endif /* LUAJIT */
+#include <signal.h>
+#include <unistd.h>
 }
 
 #include "lua_grammar.pb.h"
@@ -182,11 +184,21 @@ report_error(lua_State *L, const std::string &prefix)
 	std::cerr << prefix << " error: " << err_str << std::endl;
 }
 
+void
+sig_handler(int signo, siginfo_t *info, void *context)
+{
+	print_metrics(&metrics);
+}
+
 __attribute__((constructor))
 static void
 setup(void)
 {
 	metrics = {};
+	struct sigaction act = {};
+	act.sa_flags = SA_SIGINFO;
+	act.sa_sigaction = &sig_handler;
+	sigaction(SIGUSR1, &act, NULL);
 }
 
 __attribute__((destructor))


### PR DESCRIPTION
Test luaL_loadbuffer_proto generates random Lua programs and executes them. We want to build a fuzzing test that will produce Lua programs that will not contain semantic errors and will trigger as much as
possible components in LuaJIT.

Proposed patch introduces a metrics that gathered after running the test. LuaJIT metrics gathered using *unofficial* LuaJIT Lua function `jit.attach`. All gathered metrics test will output after running with a finite number of runs or finite duration of time (options `-runs` and `-max_total_time`).

```
$ ./build/tests/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test -runs=1000

<snipped>

Done 1000 runs in 0 second(s)
Total number of samples: 1000
Total number of samples with errors: 738 (73%)
Total number of samples with record traces: 259 (25%)
Total number of samples with start traces: 25 (2%)
Total number of samples with stop traces: 18 (1%)
Total number of samples with abort traces: 10 (1%)
Total number of samples with exit traces: 10 (1%)
Total number of samples with compiled bc: 1000 (100%)
```