### PR TITLE
tests: add lua_dump_test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,8 +65,6 @@ function(create_test)
                    -mutate_depth=20
                    -runs=5
                    -artifact_prefix=${test_name}_
-                   -dict=${PROJECT_SOURCE_DIR}/corpus/${test_prefix}.dict
-                   ${PROJECT_SOURCE_DIR}/corpus/${test_prefix}
   )
   if (USE_LUA)
     set_tests_properties(${test_name} PROPERTIES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,17 +54,19 @@ function(create_test)
   target_compile_options(${test_name} PRIVATE -Wall -Wextra -Wpedantic -Wno-unused-parameter -g)
   add_dependencies(${test_name} ${LUA_TARGET})
   string(REPLACE "_test" "" test_prefix ${test_name})
+  string(JOIN ";" LIBFUZZER_OPTS
+    -use_value_profile=1
+    -report_slow_units=5
+    -reload=1
+    -reduce_inputs=1
+    -print_pcs=1
+    -print_final_stats=1
+    -mutate_depth=20
+    -runs=5
+    -artifact_prefix=${test_name}_
+  )
   add_test(NAME ${test_name}
-           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_name}
-                   -use_value_profile=1
-                   -report_slow_units=5
-                   -reload=1
-                   -reduce_inputs=1
-                   -print_pcs=1
-                   -print_final_stats=1
-                   -mutate_depth=20
-                   -runs=5
-                   -artifact_prefix=${test_name}_
+           COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${test_name} ${LIBFUZZER_OPTS}
   )
   if (USE_LUA)
     set_tests_properties(${test_name} PROPERTIES

--- a/tests/lua_dump_test.c
+++ b/tests/lua_dump_test.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: ISC
+ *
+ * Copyright 2023, Sergey Bronnikov.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+
+#include <lua.h>
+#include <lauxlib.h>
+
+static int
+Writer(struct lua_State *L, const void *p, size_t size, void  *ud)
+{
+	/**
+	 * We are not interested in produced parts of the binary chunk.
+	 * Test does not execute a binary chunk because it is focused
+	 * on a Lua runtime frontend. Thereby, high speed of fuzzing is achieved.
+	 */
+
+	(void)L;
+	(void)p;
+	(void)ud;
+
+	/**
+	 * The writer returns an error code: 0 means no errors; any other value
+	 * means an error and stops lua_dump from calling the writer again.
+	 */
+	return 0;
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+	lua_State *L = luaL_newstate();
+	assert(L != NULL);
+
+	lua_pushlstring(L, (const char *)data, size);
+#if LUA_VERSION_NUM < 503
+	lua_dump(L, Writer, NULL);
+#else /* Lua 5.3+ */
+	lua_dump(L, Writer, NULL, 0);
+#endif /* LUA_VERSION_NUM */
+
+	lua_settop(L, 0);
+	lua_close(L);
+
+	return 0;
+}


### PR DESCRIPTION
> lua_dump() dumps a function as a binary chunk. Receives a Lua function
> on the top of the stack and produces a binary chunk that, if loaded
> again, results in a function equivalent to the one dumped. As it
> produces parts of the chunk, lua_dump calls function writer with the
> given data to write them [1].

Test does not execute a binary chunk because it is focused on a Lua runtime frontend. Thereby, high speed of fuzzing is achieved.

1. https://www.lua.org/manual/5.1/manual.html#3