### PR TITLE
cmake: support LUAJIT_RANDOM_RA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,15 @@ option(ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
 option(ENABLE_COV "Enable coverage instrumentation" OFF)
 option(ENABLE_LUA_ASSERT "Enable all assertions inside Lua source code" ON)
 option(ENABLE_LUA_APICHECK "Enable consistency checks on the C API" ON)
+option(ENABLE_LUAJIT_RANDOM_RA "Enable randomness in a register allocation" OFF)
 option(OSS_FUZZ "Enable support of OSS Fuzz" OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_INCLUDE_PATH})
+
+if (ENABLE_LUAJIT_RANDOM_RA AND NOT USE_LUAJIT)
+  message(FATAL_ERROR "Option ENABLE_LUAJIT_RANDOM_RA is LuaJIT-specific.")
+endif (ENABLE_LUAJIT_RANDOM_RA AND NOT USE_LUAJIT)
 
 if (USE_LUA AND NOT LUA_VERSION)
   set(LUA_VERSION "master")

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ CMake options:
 - `USE_LUAJIT` enables building LuaJIT.
 - `LUA_VERSION` could be a Git branch, tag or commit. By default `LUA_VERSION` is
 `master` for PUC Rio Lua and `v2.1` for LuaJIT.
+- `ENABLE_LUAJIT_RANDOM_RA` enables randomness in a register allocation. Option
+is LuaJIT-specific.
 - `ENABLE_ASAN` enables AddressSanitizer.
 - `ENABLE_UBSAN` enables UndefinedBehaviorSanitizer.
 - `ENABLE_COV` enables coverage instrumentation.

--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -20,6 +20,10 @@ macro(build_luajit LJ_VERSION)
         set(LDFLAGS "${LDFLAGS} ${CMAKE_C_FLAGS_DEBUG}")
     endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
+    if (ENABLE_LUAJIT_RANDOM_RA)
+        set(CFLAGS "${CFLAGS} -DLUAJIT_RANDOM_RA")
+    endif (ENABLE_LUAJIT_RANDOM_RA)
+
     if (ENABLE_ASAN)
         set(CFLAGS "${CFLAGS} -fsanitize=address")
         set(CFLAGS "${CFLAGS} -DLUAJIT_USE_ASAN")


### PR DESCRIPTION
The patch adds support of the option `LUAJIT_RANDOM_RA` that causes the register allocator to (often) randomly choose any register from the allowed set, rather than the default (and highly desirable) behaviour of choosing a free or cheaply evictable register, which helps to exercise rare cases and flush out bugs, see [1].

1. https://github.com/LuaJIT/LuaJIT/commit/41fb94defa8f830ce69a8122b03f6ac3216d392a