### PR TITLE
tests: disable lua_dump_test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ list(APPEND LUAJIT_BLACKLIST_TESTS "lua_stringtonumber_test")
 list(APPEND BLACKLIST_TESTS "luaL_dostring_test")
 list(APPEND BLACKLIST_TESTS "luaL_loadbuffer_test")
 list(APPEND BLACKLIST_TESTS "luaL_loadstring_test")
+list(APPEND BLACKLIST_TESTS "lua_dump_test")
 
 file(GLOB tests LIST_DIRECTORIES false ${CMAKE_CURRENT_SOURCE_DIR} *.c *.cc)
 foreach(filename ${tests})


### PR DESCRIPTION
`lua_dump()` receives a Lua function on the top of the stack and this requires running `luaL_loadstring()` or similar function. However, translation junk to bytecode is unsafe in LuaJIT.
Disable test until we have a mutations in Lua code.