### PR TITLE
cmake: enable hardware-assisted Address Sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_program(SHELL sh)
 
 option(USE_LUA "Use PUC Rio Lua library" OFF)
 option(USE_LUAJIT "Use LuaJIT library" OFF)
-option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+option(ENABLE_ASAN "Enable [Hardware]AddressSanitizer" OFF)
 option(ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
 option(ENABLE_COV "Enable coverage instrumentation" OFF)
 option(ENABLE_LUA_ASSERT "Enable all assertions inside Lua source code" ON)
@@ -70,5 +70,18 @@ if(ENABLE_COV)
 endif()
 
 enable_testing()
+
+set(ASAN_TYPE "address")
+# https://android.googlesource.com/platform/external/swiftshader/+/refs/heads/master/CMakeLists.txt#45
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm" OR
+    CMAKE_SYSTEM_PROCESSOR MATCHES "aarch")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(ASAN_TYPE "hwaddress")
+    endif ()
+endif ()
+if (CMAKE_OSX_ARCHITECTURES AND
+    CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+    set(ASAN_TYPE "hwaddress")
+endif ()
 
 add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ CMake options:
 `master` for PUC Rio Lua and `v2.1` for LuaJIT.
 - `ENABLE_LUAJIT_RANDOM_RA` enables randomness in a register allocation. Option
 is LuaJIT-specific.
-- `ENABLE_ASAN` enables AddressSanitizer.
+- `ENABLE_ASAN` enables HardwareAddressSanitizer on AArch64 and
+  AddressSanitizer on other architectures.
 - `ENABLE_UBSAN` enables UndefinedBehaviorSanitizer.
 - `ENABLE_COV` enables coverage instrumentation.
 - `ENABLE_LUA_ASSERT` enables all assertions inside Lua source code.

--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -23,8 +23,8 @@ macro(build_lua LUA_VERSION)
     endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
     if (ENABLE_ASAN)
-        set(CFLAGS "${CFLAGS} -fsanitize=address -fsanitize=pointer-subtract -fsanitize=pointer-compare")
-        set(LDFLAGS "${LDFLAGS} -fsanitize=address")
+        set(CFLAGS "${CFLAGS} -fsanitize=${ASAN_TYPE} -fsanitize=pointer-subtract -fsanitize=pointer-compare")
+        set(LDFLAGS "${LDFLAGS} -fsanitize=${ASAN_TYPE}")
     endif (ENABLE_ASAN)
 
     if (ENABLE_UBSAN)

--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -25,10 +25,10 @@ macro(build_luajit LJ_VERSION)
     endif (ENABLE_LUAJIT_RANDOM_RA)
 
     if (ENABLE_ASAN)
-        set(CFLAGS "${CFLAGS} -fsanitize=address")
+        set(CFLAGS "${CFLAGS} -fsanitize=${ASAN_TYPE}")
         set(CFLAGS "${CFLAGS} -DLUAJIT_USE_ASAN")
         set(CFLAGS "${CFLAGS} -DLUAJIT_USE_SYSMALLOC=1")
-        set(LDFLAGS "${LDFLAGS} -fsanitize=address")
+        set(LDFLAGS "${LDFLAGS} -fsanitize=${ASAN_TYPE}")
     endif (ENABLE_ASAN)
 
     if (ENABLE_UBSAN)


### PR DESCRIPTION
Hardware-assisted AddressSanitizer (HWASan) is a memory error detection tool similar to AddressSanitizer. HWASan uses a lot less RAM compared to ASan, which makes it suitable for whole system sanitization. HWASan is only available on Android 10 and higher, and only on AArch64 hardware.

Compared to classic ASan, HWASan has:

- Similar CPU overhead (~2x)
- Similar code size overhead (40 – 50%)
- Much smaller RAM overhead (10% – 35%)

HWASan detects the same set of bugs as ASan:

- Stack and heap buffer overflow/underflow
- Heap use after free
- Stack use outside scope
- Double free and wild free

1. https://clang.llvm.org/docs/HardwareAssistedAddressSanitizerDesign.html
2. https://source.android.com/docs/security/test/hwasan