### PR TITLE
cmake: enable ENABLE_LUA_ASSERT

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -50,6 +50,6 @@ jobs:
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: 'lua'
-          fuzz-seconds: 10
+          fuzz-seconds: 30
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}

--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -6,11 +6,6 @@ macro(build_lua LUA_VERSION)
 
     set(CFLAGS ${CMAKE_C_FLAGS})
     if (ENABLE_LUA_ASSERT)
-        # See https://marc.info/?l=lua-l&m=169289729129364&w=2
-        message(WARNING "Option ENABLE_LUA_ASSERT is disabled")
-        set(ENABLE_LUA_ASSERT OFF)
-    endif (ENABLE_LUA_ASSERT)
-    if (ENABLE_LUA_ASSERT)
         set(CFLAGS "${CFLAGS} -DLUAI_ASSERT")
     endif (ENABLE_LUA_ASSERT)
     if (ENABLE_LUA_APICHECK)

--- a/tests/lua_load_test.c
+++ b/tests/lua_load_test.c
@@ -36,8 +36,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	luaL_openlibs(L);
 
 	FILE *fd = fmemopen((void *)data, size, "r");
-	if (fd == NULL)
+	if (fd == NULL) {
+		lua_close(L);
 		return 0;
+	}
 
 	dt test_data;
 	test_data.fd = fd;


### PR DESCRIPTION
Commit 2d803e38b6e9 ("cmake: introduce options ENABLE_LUA_ASSERT and ENABLE_LUA_APICHECK") disabled ENABLE_LUA_ASSERT for PUC Rio Lua by default due to regression introduced in [1].

Now regression has been fixed by commit [2] and ENABLE_LUA_ASSERT can be enabled back.

1. https://github.com/lua/lua/commit/9b4f39ab14fb2e55345c3d23537d129dac23b091
2. https://github.com/lua/lua/commit/07a9eab23ac073362f231ddc7215688cf221ff45