### PR TITLE
ci: fix broken OSS Fuzz workflow

### DIFF
--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -50,6 +50,6 @@ jobs:
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
         with:
           oss-fuzz-project-name: 'lua'
-          fuzz-seconds: 10
+          fuzz-seconds: 30
           dry-run: false
           sanitizer: ${{ matrix.sanitizer }}

--- a/tests/lua_load_test.c
+++ b/tests/lua_load_test.c
@@ -36,8 +36,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	luaL_openlibs(L);
 
 	FILE *fd = fmemopen((void *)data, size, "r");
-	if (fd == NULL)
+	if (fd == NULL) {
+		lua_close(L);
 		return 0;
+	}
 
 	dt test_data;
 	test_data.fd = fd;


### PR DESCRIPTION
OSS Fuzz workflow has failed due to assert:

```
2023-09-26 10:00:12,722 - root - INFO - Starting fuzzing
Traceback (most recent call last):
  File "/opt/oss-fuzz/infra/cifuzz/run_fuzzers_entrypoint.py", line 96, in <module>
    sys.exit(main())
  File "/opt/oss-fuzz/infra/cifuzz/run_fuzzers_entrypoint.py", line 92, in main
    return run_fuzzers_entrypoint()
  File "/opt/oss-fuzz/infra/cifuzz/run_fuzzers_entrypoint.py", line 62, in run_fuzzers_entrypoint
    result = run_fuzzers.run_fuzzers(config)
  File "/opt/oss-fuzz/infra/cifuzz/run_fuzzers.py", line 316, in run_fuzzers
    if not fuzz_target_runner.run_fuzz_targets():
  File "/opt/oss-fuzz/infra/cifuzz/run_fuzzers.py", line 131, in run_fuzz_targets
    result = self.run_fuzz_target(target)
  File "/opt/oss-fuzz/infra/cifuzz/run_fuzzers.py", line 259, in run_fuzz_target
    return fuzz_target_obj.fuzz()
  File "/opt/oss-fuzz/infra/cifuzz/fuzz_target.py", line 195, in fuzz
    result = engine_impl.fuzz(self.target_path, options, artifacts_dir,
  File "/usr/local/lib/python3.8/dist-packages/clusterfuzz/_internal/bot/fuzzers/libFuzzer/engine.py", line 278, in fuzz
    fuzz_result = runner.fuzz(
  File "/usr/local/lib/python3.8/dist-packages/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py", line [40](https://github.com/ligurio/lua-c-api-tests/actions/runs/6311004556/job/17134116743?pr=51#step:5:41)1, in fuzz
    return LibFuzzerCommon.fuzz(self, corpus_directories, fuzz_timeout,
  File "/usr/local/lib/python3.8/dist-packages/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py", line 200, in fuzz
    assert max_total_time > 0
AssertionError
```

This happened because fuzzing total time (`fuzz-seconds`) in GH workflow was equal to a default timeout in [1] and therefore `max_total_time` was equal to zero. The patch fixes that by setting a bigger value to `fuzz-seconds`.

1. https://github.com/google/clusterfuzz/blob/298cecc64af7ecbb1c528dd1789e999caa6af825/src/clusterfuzz/_internal/bot/fuzzers/libfuzzer.py#L84

Part of https://github.com/google/oss-fuzz/issues/11017