### PR TITLE
cmake: support building code coverage report

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,10 @@ endif (NOT Protobuf_FOUND)
 
 SetBuildParallelLevel(CMAKE_BUILD_PARALLEL_LEVEL)
 
+if(ENABLE_COV)
+    include(CodeCoverage)
+endif()
+
 enable_testing()
 
 add_subdirectory(tests)

--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -52,8 +52,8 @@ macro(build_lua LUA_VERSION)
     endif (ENABLE_UBSAN)
 
     if (ENABLE_COV)
-        set(CFLAGS "${CFLAGS} -fprofile-instr-generate -fcoverage-mapping")
-        set(LDFLAGS "${LDFLAGS} -fprofile-instr-generate -fcoverage-mapping")
+        set(CFLAGS "${CFLAGS} -fprofile-instr-generate  -fprofile-arcs -fcoverage-mapping -ftest-coverage")
+        set(LDFLAGS "${LDFLAGS} -fprofile-instr-generate -fprofile-arcs -fcoverage-mapping -ftest-coverage")
     endif (ENABLE_COV)
 
 
@@ -88,7 +88,6 @@ macro(build_lua LUA_VERSION)
     set(LUA_VERSION_STRING "PUC Rio Lua ${LUA_VERSION}")
     set(LUA_TARGET patched-lua-${LUA_VERSION})
 
-    unset(LUA_SOURCE_DIR)
     unset(LUA_BINARY_DIR)
     unset(LUA_PATCH_PATH)
 endmacro(build_lua)

--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -67,8 +67,8 @@ macro(build_luajit LJ_VERSION)
     endif (ENABLE_UBSAN)
 
     if (ENABLE_COV)
-        set(CFLAGS "${CFLAGS} -fprofile-instr-generate -fcoverage-mapping")
-        set(LDFLAGS "${LDFLAGS} -fprofile-instr-generate -fcoverage-mapping")
+        set(CFLAGS "${CFLAGS} -fprofile-instr-generate -fprofile-arcs -fcoverage-mapping -ftest-coverage")
+        set(LDFLAGS "${LDFLAGS} -fprofile-instr-generate -fprofile-arcs -fcoverage-mapping -ftest-coverage")
     endif (ENABLE_COV)
 
 
@@ -100,6 +100,7 @@ macro(build_luajit LJ_VERSION)
         BUILD_BYPRODUCTS ${LJ_SOURCE_DIR}/src/libluajit.a
     )
 
+    set(LUA_SOURCE_DIR ${LJ_SOURCE_DIR})
     set(LUA_INCLUDE_DIR ${LJ_SOURCE_DIR}/src/)
     set(LUA_LIBRARIES ${LJ_SOURCE_DIR}/src/libluajit.a)
     set(LUA_VERSION_STRING "LuaJIT ${LJ_VERSION}")

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,0 +1,55 @@
+find_program(GCOVR gcovr)
+find_program(LLVM_COV llvm-cov)
+
+set(COVERAGE_DIR "${PROJECT_BINARY_DIR}/coverage")
+set(COVERAGE_HTML_REPORT "${COVERAGE_DIR}/report.html")
+set(COVERAGE_XML_REPORT "${COVERAGE_DIR}/report.xml")
+
+if(NOT GCOVR OR NOT LLVM_COV)
+  set(MSG "coverage-report is a dummy target")
+  add_custom_target(coverage-report
+    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --red ${MSG}
+  )
+  message(WARNING "Either `gcovr' or `llvm-cov` not found, "
+                  "so ${PROJECT_NAME}-coverage target is dummy.")
+  return()
+endif()
+
+# See https://gcovr.com/en/stable/manpage.html.
+set(GCOVR_OPTIONS
+  --branches
+  --cobertura ${COVERAGE_XML_REPORT}
+  --decisions
+  --gcov-executable "llvm-cov gcov"
+  --html
+  --html-details
+  --html-title "Code Coverage Report"
+  -j ${CMAKE_BUILD_PARALLEL_LEVEL}
+  --output ${COVERAGE_HTML_REPORT}
+  --print-summary
+  --root ${LUA_SOURCE_DIR}
+  --sort-percentage
+)
+
+if(USE_LUA)
+  set(GCOVR_OPTIONS ${GCOVR_OPTIONS} --object-directory ${LUA_SOURCE_DIR})
+endif ()
+
+if(USE_LUAJIT)
+  # Exclude DynASM files, that contain a low-level VM code for CPUs.
+  set(GCOVR_OPTIONS ${GCOVR_OPTIONS} --exclude ".*\.dasc")
+  # Exclude buildvm source code, it's a project's build infrastructure.
+  set(GCOVR_OPTIONS ${GCOVR_OPTIONS} --exclude ".*/host/")
+  set(GCOVR_OPTIONS ${GCOVR_OPTIONS} --object-directory ${LUA_SOURCE_DIR}/src)
+endif (USE_LUAJIT)
+
+file(MAKE_DIRECTORY ${COVERAGE_DIR})
+add_custom_target(coverage-report)
+add_custom_command(TARGET coverage-report
+  COMMENT "Building coverage report"
+  COMMAND ${GCOVR} ${GCOVR_OPTIONS}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)
+
+message(STATUS "Code coverage HTML report: ${COVERAGE_HTML_REPORT}")
+message(STATUS "Code coverage XML report: ${COVERAGE_XML_REPORT}")


### PR DESCRIPTION
The patch adds building code coverage report using gcovr [1] and llvm-cov. gcovr is a better version of lcov, see [2].

New CMake target "coverage-report" processes *.gcno and *.gcda files with llvm-cov, builds a detailed HTML report using gcovr and prints a summary. This target doesn't run any tests.

```
$ CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COV=ON -DUSE_LUA=ON $ RUNS=1 cmake --build build --parallel --target test $ cmake --build build --parallel --target coverage-report Building coverage report
(INFO) - MainThread - Reading coverage data...
(INFO) - MainThread - Writing coverage report...
lines: 59.4% (6974 out of 11733)
functions: 65.0% (683 out of 1050)
branches: 43.3% (4705 out of 10863)
decisions: 55.5% (1782 out of 3208)
Built target coverage-report
```

1. https://gcovr.com/
2. https://gcovr.com/en/stable/faq.html#what-is-the-difference-between-lcov-and-gcovr
3. https://llvm.org/docs/CommandGuide/llvm-cov.html
4. https://gcovr.com/en/5.1/guide/compiling.html#choosing-the-right-gcov-executable