### PR TITLE
cmake: add presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 crash-*
 leak-*
 *.swp
+CMakeUserPresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,148 @@
+{
+  "version": 7,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 27,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "configure_default",
+      "displayName": "Default config",
+      "description": "Default build",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "ENABLE_COV": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "ENABLE_ASAN": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "ENABLE_LUA_ASSERT": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "ENABLE_LUA_APICHECK": {
+          "type": "BOOL",
+          "value": "TRUE"
+        },
+        "ENABLE_BUILD_PROTOBUF": {
+          "type": "BOOL",
+          "value": "FALSE"
+        }
+      }
+    },
+    {
+      "name": "configure_lua",
+      "inherits": "configure_default",
+      "displayName": "PUC Rio Lua",
+      "binaryDir": "${sourceDir}/build/lua",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "USE_LUA": {
+          "type": "BOOL",
+          "value": "TRUE"
+        }
+      }
+    },
+    {
+      "name": "configure_luajit",
+      "inherits": "configure_default",
+      "displayName": "LuaJIT",
+      "binaryDir": "${sourceDir}/build/luajit",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "USE_LUAJIT": {
+          "type": "BOOL",
+          "value": "TRUE"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build_default",
+      "configurePreset": "configure_default",
+      "jobs": 10,
+      "verbose": true
+    },
+    {
+      "name": "build_lua",
+      "displayName": "PUC Rio Lua",
+      "configurePreset": "configure_lua",
+      "inherits": "build_default"
+    },
+    {
+      "name": "build_luajit",
+      "displayName": "LuaJIT",
+      "configurePreset": "configure_luajit",
+      "inherits": "build_default"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "test_default",
+      "configurePreset": "configure_default",
+      "output": {"outputOnFailure": true, "verbosity": "verbose"}
+    },
+    {
+      "name": "test_lua",
+      "displayName": "PUC Rio Lua",
+      "configurePreset": "configure_lua",
+      "inherits": "test_default"
+    },
+    {
+      "name": "test_luajit",
+      "displayName": "LuaJIT",
+      "configurePreset": "configure_luajit",
+      "inherits": "test_default"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "lua",
+      "displayName": "PUC Rio Lua",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "configure_lua"
+        },
+        {
+          "type": "build",
+          "name": "build_lua"
+        },
+        {
+          "type": "test",
+          "name": "test_lua"
+        }
+      ]
+    },
+    {
+      "name": "luajit",
+      "displayName": "LuaJIT",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "configure_luajit"
+        },
+        {
+          "type": "build",
+          "name": "build_luajit"
+        },
+        {
+          "type": "test",
+          "name": "test_luajit"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
One problem that CMake users often face is sharing settings with other
people for common ways to configure a project. CMake supports two main
files, `CMakePresets.json` and `CMakeUserPresets.json`, that allow users
to specify common configure options.

`CMakePresets.json` and `CMakeUserPresets.json` live in the project's
root directory. They both have exactly the same format, and both are
optional (though at least one must be present if `--preset` is
specified). `CMakePresets.json` is meant to specify project-wide build
details, while `CMakeUserPresets.json` is meant for developers to
specify their own local build details.

`CMakePresets.json` is tracked by Git and added into a repository, and
`CMakeUserPresets.json` is not tracked by Git and thus added to the
`.gitignore`.

The patch add `CMakePresets.json` with two workflows: `lua` and
`luajit`. Both workflows configures, builds and tests Lua library.

Usage:

```
$ cmake --list-presets
$ cmake --list-presets=all .
$ cmake --preset {configure_lua,configure_luajit}
$ cmake --build --preset {build_lua,build_luajit}
$ ctest --preset {test_lua,test_luajit}
$ cmake --workflow --preset {lua,luajit}
```

1. https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html