### PR TITLE
cmake: update source repository on rebuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18)
 
 project(lua-c-api-tests
   LANGUAGES C CXX

--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -64,6 +64,7 @@ macro(build_lua LUA_VERSION)
         GIT_TAG ${LUA_VERSION}
         GIT_PROGRESS TRUE
         GIT_SHALLOW FALSE
+        GIT_REMOTE_UPDATE_STRATEGY REBASE
 
         SOURCE_DIR ${LUA_SOURCE_DIR}
         BINARY_DIR ${LUA_BINARY_DIR}
@@ -78,7 +79,6 @@ macro(build_lua LUA_VERSION)
                                                  LDFLAGS=${LDFLAGS}
                                                  a
         INSTALL_COMMAND ""
-        UPDATE_DISCONNECTED ON
 
         BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/lua-${LUA_VERSION}/source/liblua.a
     )

--- a/cmake/BuildLuaJIT.cmake
+++ b/cmake/BuildLuaJIT.cmake
@@ -79,6 +79,7 @@ macro(build_luajit LJ_VERSION)
         GIT_TAG ${LJ_VERSION}
         GIT_PROGRESS TRUE
         GIT_SHALLOW FALSE
+        GIT_REMOTE_UPDATE_STRATEGY REBASE
 
         SOURCE_DIR ${LJ_SOURCE_DIR}
         BINARY_DIR ${LJ_BINARY_DIR}/luajit-${LJ_VERSION}
@@ -95,7 +96,6 @@ macro(build_luajit LJ_VERSION)
                                                  -C src
                                                  libluajit.a
         INSTALL_COMMAND ""
-        UPDATE_DISCONNECTED ON
 
         BUILD_BYPRODUCTS ${LJ_SOURCE_DIR}/src/libluajit.a
     )


### PR DESCRIPTION
The project builds a Lua library that used for building tests using `ExternalProject_Add` in CMake modules. Previously, source repositories with Lua libraries (Lua and LuaJIT) were not updated automatically on rebuilding tests and building tests with updated Lua libraries required rebuild from scratch.

The patch disables `UPDATE_DISCONNECTED` in `ExternalProject_Add` and sets `GIT_REMOTE_UPDATE_STRATEGY` to `REBASE` [1].

After these changes CMake will try to rebase the current branch to the one specified by `LUA_VERSION`. If there are local uncommitted changes, they will be stashed first and popped again after rebasing. If rebasing or popping stashed changes fail, abort the rebase and halt with an error. The strategy could be overriden with
`CMAKE_EP_GIT_REMOTE_UPDATE_STRATEGY`.

1. https://cmake.org/cmake/help/latest/module/ExternalProject.html