### PR TITLE
tests/luaL_loadbufferx_test: enable back for LuaJIT

### DIFF
--- a/tests/capi/CMakeLists.txt
+++ b/tests/capi/CMakeLists.txt
@@ -99,8 +99,6 @@ list(APPEND LUAJIT_BLACKLIST_TESTS "luaL_buffsub_test")
 list(APPEND LUAJIT_BLACKLIST_TESTS "luaL_buffaddr_test")
 list(APPEND LUAJIT_BLACKLIST_TESTS "lua_load_test")
 list(APPEND LUAJIT_BLACKLIST_TESTS "lua_stringtonumber_test")
-# See https://github.com/ligurio/lua-c-api-tests/issues/56
-list(APPEND LUAJIT_BLACKLIST_TESTS "luaL_loadbufferx_test")
 
 # https://github.com/ligurio/lua-c-api-tests/issues/19
 list(APPEND BLACKLIST_TESTS "luaL_dostring_test")

--- a/tests/capi/luaL_loadbufferx_test.c
+++ b/tests/capi/luaL_loadbufferx_test.c
@@ -29,20 +29,10 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	 * (that is, a precompiled chunk). It may be the string "b" (only binary
 	 * chunks), "t" (only text chunks), or "bt" (both binary and text). The
 	 * default is "bt".
-	 * Lua runtime (at least PUC Rio Lua and LuaJIT) has bytecode and Lua
-	 * parsers. It is desired to test both parsers, however, in LuaJIT
-	 * bytecode parser failed with assertion:
-	 *
-	 * LuaJIT ASSERT lj_bcread.c:123: bcread_byte: buffer read overflow
-	 *
-	 * so in LuaJIT only text mode is used and therefore only text parser is
-	 * tested.
+	 * Seed corpus is shared by different Lua runtimes (PUC Rio Lua and LuaJIT),
+	 * enabling binary mode could lead false positive crashes in LuaJIT.
 	 */
-#ifdef LUAJIT
 	const char *mode = "t";
-#else
-	const char *mode = "bt";
-#endif /* LUAJIT */
 	luaL_loadbufferx(L, (const char *)data, size, "fuzz", mode);
 
 	lua_settop(L, 0);


### PR DESCRIPTION
Commit 8923c9252cc4 ("tests: update luaL_loadbufferx_test") updated test luaL_loadbufferx_test: test use binary and text mode for PUC Rio Lua and text mode only for LuaJIT. However, test uses a seed corpus that is shared for both Lua implementations, and I suppose crashes like below were happened due to this.

```
SCARINESS: 51 (8-byte-read-heap-use-after-free)
    #0 0x5de26e in lj_gc_finalize_cdata /src/testdir/build/luajit-v2.1/source/src/lj_gc.c:591:18
    #1 0x56c037 in cpfinalize /src/testdir/build/luajit-v2.1/source/src/lj_state.c:289:3
    #2 0x5da933 in lj_vm_cpcall /src/testdir/build/luajit-v2.1/source/src/lj_vm.S:1250
    #3 0x56bee4 in lua_close /src/testdir/build/luajit-v2.1/source/src/lj_state.c:316:9
    #4 0x569f44 in LLVMFuzzerTestOneInput /src/testdir/tests/luaL_loadbufferx_test.c:43:2
```

The commit disabled binary mode and left text mode only.

Fixes #56