### PR TITLE
tests: enable debug information in lua_dump

### DIFF
--- a/tests/capi/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc
+++ b/tests/capi/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc
@@ -302,7 +302,7 @@ luaL_loadbytecode(lua_State *L, const char *buff, size_t sz, const char *name)
 #if LUA_VERSION_NUM < 503
 	rc = lua_dump(L, writer, &state);
 #else /* Lua 5.3+ */
-	rc = lua_dump(L, writer, &state, 1);
+	rc = lua_dump(L, writer, &state, 0);
 #endif /* LUA_VERSION_NUM */
 	if (rc != 0) {
 		return rc;


### PR DESCRIPTION
Disable strip of debug information about the function passed to `lua_dump`, see [1]:

> If strip is true, the binary representation may not
> include all debug information about the function, to save space.

This change is likely to increase the code coverage.

1. https://www.lua.org/manual/5.3/manual.html#lua_dump