### PR TITLE
Speedup string serialization

### DIFF
--- a/tests/capi/luaL_loadbuffer_proto/serializer.cc
+++ b/tests/capi/luaL_loadbuffer_proto/serializer.cc
@@ -444,6 +444,8 @@ ClearIdentifier(const std::string &identifier)
 		} else if (std::isalpha(c) || c == '_') {
 			has_first_not_digit = true;
 			cleared += c;
+		} else {
+			cleared += '_';
 		}
 	}
 	return cleared;
@@ -465,12 +467,13 @@ clamp(double number, double upper, double lower)
 }
 
 inline std::string
-ConvertToStringDefault(const std::string &s)
+ConvertToStringDefault(const std::string &s, bool sanitize = false)
 {
-	std::string ident = ClearIdentifier(s);
-	ident = clamp(ident);
+	std::string ident = clamp(s);
+	if (sanitize)
+		ident = ClearIdentifier(ident);
 	if (ident.empty())
-		return std::string(kDefaultIdent);
+		ident = std::string(kDefaultIdent);
 	return ident;
 }
 
@@ -960,7 +963,7 @@ NESTED_PROTO_TOSTRING(IndexWithName, indexname, Variable)
 {
 	std::string indexname_str = PrefixExpressionToString(
 		indexname.prefixexp());
-	std::string idx_str = ConvertToStringDefault(indexname.name());
+	std::string idx_str = ConvertToStringDefault(indexname.name(), true);
 	/* Prevent using reserved keywords as indices. */
 	if (KReservedLuaKeywords.find(idx_str) != KReservedLuaKeywords.end()) {
 		idx_str += "_1";
@@ -1205,8 +1208,12 @@ PROTO_TOSTRING(UnaryOperator, op)
  */
 PROTO_TOSTRING(Name, name)
 {
-	std::string ident = ConvertToStringDefault(name.name());
-	return ident + std::to_string(name.num() % kMaxIdentifiers);
+	std::string ident = ConvertToStringDefault(name.name(), true);
+	/* Identifier has default name, add an index. */
+	if (!ident.compare(kDefaultIdent)) {
+		ident += std::to_string(name.num() % kMaxIdentifiers);
+	}
+	return ident;
 }
 
 } /* namespace */


### PR DESCRIPTION
- clamp before cleaning string because cleaning is not cheap (O(n), where max `n` is equal to `kMaxStrLength`)
- call cleaning for identifiers only, there is no sense to cleaning string literals
- replace not allowed symbols in indentifier's names with '_'

This change saves 16 sec on 145k samples (before 401 sec and after 385 sec). It is actually not so much, but it is a 2.5 min per hour.