### PR TITLE
tests: update message on creating test

### DIFF
--- a/tests/capi/CMakeLists.txt
+++ b/tests/capi/CMakeLists.txt
@@ -80,7 +80,7 @@ function(create_test)
   add_test(NAME ${test_name}
            COMMAND ${SHELL} -c "$<TARGET_FILE:${test_name}> ${LIBFUZZER_OPTS}"
   )
-  message(STATUS "Creating test ${test_name}")
+  message(STATUS "Creating Lua C API test ${test_name}")
   if (USE_LUA)
     set_tests_properties(${test_name} PROPERTIES
       ENVIRONMENT "ASAN_OPTIONS='detect_invalid_pointer_pairs=2'"


### PR DESCRIPTION
The patch changes a message that CMake outputs on creating a CTest test, now message highlights that it is a Lua C API test. It is needed to distinquish with Lua API tests.

The patch follows up commit e0216377d750 ("cmake: put C API tests to a separate subdirectory").