### PR TITLE
cfl: change a version of gh action

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -25,12 +25,12 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Build fuzzing tests (${{ matrix.sanitizer }})
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@main
         with:
           sanitizer: ${{ matrix.sanitizer }}
       - name: Run fuzzing tests (${{ matrix.sanitizer }})
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@main
         with:
           fuzz-seconds: 3600
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Build fuzzing tests (${{ matrix.sanitizer }})
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@main
         with:
           language: c
           sanitizer: ${{ matrix.sanitizer }}

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Build fuzzing tests
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@main
         with:
           sanitizer: coverage
       - name: Run fuzzing tests
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@main
         with:
           fuzz-seconds: 600
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,10 +52,10 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Build Fuzzers
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@main
       - name: Run Fuzzers
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@main
         with:
           fuzz-seconds: 1800
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Build fuzzing tests (${{ matrix.sanitizer }})
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@main
         with:
           language: c
           sanitizer: ${{ matrix.sanitizer }}
@@ -54,7 +54,7 @@ jobs:
           storage-repo-branch-coverage: gh-pages
       - name: Run fuzzing tests (${{ matrix.sanitizer }})
         id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@main
         with:
           fuzz-seconds: 120
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GH Action with enabled options `report-timeouts` and `report-ooms` [1][2] is not released yet. The patch changes a version to `master` to allow using of aforementioned options.

1. https://github.com/google/oss-fuzz/issues/11723
2. https://github.com/google/clusterfuzzlite/pull/138