### PR TITLE
cmake: introduce an option ENABLE_INTERNAL_TESTS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,7 @@ jobs:
         run: |
           cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
                 -DUSE_LUA=ON -DENABLE_BUILD_PROTOBUF=OFF \
+                -DENABLE_INTERNAL_TESTS=ON \
                 -G Ninja -S . -B build
         if: ${{ matrix.LUA == 'lua' }}
 
@@ -66,6 +67,7 @@ jobs:
         run: |
           cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
                 -DUSE_LUAJIT=ON -DENABLE_BUILD_PROTOBUF=OFF \
+                -DENABLE_INTERNAL_TESTS=ON \
                 -G Ninja -S . -B build
         if: ${{ matrix.LUA == 'luajit' }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(ENABLE_LUAJIT_RANDOM_RA "Enable randomness in a register allocation" OFF)
 option(OSS_FUZZ "Enable support of OSS Fuzz" OFF)
 option(ENABLE_BUILD_PROTOBUF "Enable building Protobuf library" ON)
 option(ENABLE_BONUS_TESTS "Enable bonus tests" OFF)
+option(ENABLE_INTERNAL_TESTS "Enable internal tests" OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_INCLUDE_PATH})

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ is LuaJIT-specific.
 - `OSS_FUZZ` enables support of OSS Fuzz.
 - `ENABLE_BUILD_PROTOBUF` enables building Protobuf library, otherwise system
   library is used.
+- `ENABLE_INTERNAL_TESTS` enables internal tests.
 
 ### Running
 

--- a/libluamut/CMakeLists.txt
+++ b/libluamut/CMakeLists.txt
@@ -21,4 +21,6 @@ target_include_directories(${LIB_LUA_CROSSOVER} PRIVATE ${LUA_INCLUDE_DIR})
 target_compile_options(${LIB_LUA_CROSSOVER} PRIVATE ${CFLAGS})
 add_dependencies(${LIB_LUA_CROSSOVER} ${LUA_TARGET})
 
-add_subdirectory(tests)
+if (ENABLE_INTERNAL_TESTS)
+  add_subdirectory(tests)
+endif()


### PR DESCRIPTION
The patch introduce an option ENABLE_INTERNAL_TESTS, it is disabled by default.

Follows up commit 2ec5436e90f1 ("libluamut: initial version").