### PR TITLE
cfl: disable building protobuf library

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -7,7 +7,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder:v1
 
 RUN apt-get update && apt-get install -y \
-	build-essential ninja-build cmake make \
+	build-essential cmake make \
 	libreadline-dev libunwind-dev zlib1g-dev \
 	protobuf-compiler libprotobuf-dev
 

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -7,7 +7,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder:v1
 
 RUN apt-get update && apt-get install -y \
-	build-essential cmake make \
+	build-essential ninja-build cmake make \
 	libreadline-dev libunwind-dev zlib1g-dev \
 	protobuf-compiler libprotobuf-dev
 

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -8,7 +8,8 @@ FROM gcr.io/oss-fuzz-base/base-builder:v1
 
 RUN apt-get update && apt-get install -y \
 	build-essential ninja-build cmake make \
-	libreadline-dev libunwind-dev zlib1g-dev
+	libreadline-dev libunwind-dev zlib1g-dev \
+	protobuf-compiler libprotobuf-dev
 
 COPY . $SRC/lua-c-api-tests
 WORKDIR $SRC/lua-c-api-tests

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -52,7 +52,7 @@ git config --global --add safe.directory '*'
 
 # Build the project and fuzzers.
 [[ -e build ]] && rm -rf build
-cmake "${cmake_args[@]}" -S . -B build -G Ninja
+cmake "${cmake_args[@]}" -S . -B build
 cmake --build build --parallel
 
 cp corpus/*.dict corpus/*.options $OUT/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -52,7 +52,7 @@ git config --global --add safe.directory '*'
 
 # Build the project and fuzzers.
 [[ -e build ]] && rm -rf build
-cmake "${cmake_args[@]}" -S . -B build
+cmake "${cmake_args[@]}" -S . -B build -G Ninja
 cmake --build build --parallel
 
 cp corpus/*.dict corpus/*.options $OUT/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -29,6 +29,7 @@ esac
 cmake_args=(
     -DUSE_LUAJIT=ON
     -DOSS_FUZZ=ON
+    -DENABLE_BUILD_PROTOBUF=OFF
     $SANITIZERS_ARGS
 
     # C compiler


### PR DESCRIPTION
The patch disables building protobuf library, this will speed up overall build time significantly.