### PR TITLE
corpus: remove submodule

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -12,6 +12,5 @@ RUN apt-get update && apt-get install -y \
 
 COPY . $SRC/lua-c-api-tests
 WORKDIR $SRC/lua-c-api-tests
-RUN rm -rf corpus
 RUN git clone --depth 1 --branch cfl https://github.com/ligurio/lua-c-api-corpus corpus
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,9 +37,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          submodules: recursive
 
       - name: Setup common packages
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "corpus"]
-	path = corpus
-	url = https://github.com/ligurio/lua-c-api-corpus

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ LuaJIT).
 ### Building
 
 ```sh
-git clone --jobs $(nproc) --recursive https://github.com/ligurio/lua-c-api-tests
+git clone https://github.com/ligurio/lua-c-api-tests
+cd lua-c-api-tests
+git clone https://github.com/ligurio/lua-c-api-corpus
 CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DUSE_LUA=ON [-DUSE_LUAJIT=ON]
 cmake --build build --parallel
 ```


### PR DESCRIPTION
A Git submodule was introduced in commit 341ac1ea1619 ("corpus: initial integration"). The main idea was to keep in sync source code of tests and their seed corpus.
However, this approach is not convenient:

- seed corpus updates often and someone need to regularly bump submodule version, otherwise outdated seed corpus is used
- seed corpus takes about 5Gb and git clone of repository with tests takes significant time