### PR TITLE
test/capi: fix compiler warning in profiler_cb

### DIFF
--- a/tests/capi/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc
+++ b/tests/capi/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc
@@ -181,11 +181,10 @@ metrics_increment_num_error_samples(struct metrics *metrics)
 }
 
 UNUSED static void
-profiler_cb(lua_State *L, void *data, size_t *size)
+profiler_cb(lua_State *L, void *data, int samples, int vmstate)
 {
 	(void)L;
 	(void)data;
-	(void)size;
 	/* Do nothing. */
 }
 


### PR DESCRIPTION
The patch fixes a compiler warning:

```
/home/sergeyb/sources/lua-c-api-tests/tests/capi/luaL_loadbuffer_proto/luaL_loadbuffer_proto_test.cc:371:32: warning: cast from 'void (*)(lua_State
 *, void *, size_t *)' (aka 'void (*)(lua_State *, void *, unsigned long *)') to 'luaJIT_profile_callback' (aka 'void (*)(void *, lua_State *, int,
 int)') converts to incompatible function type [-Wcast-function-type-mismatch]
  371 |         luaJIT_profile_start(L, mode, (luaJIT_profile_callback)profiler_cb, NULL);
      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```