### PR TITLE
ci: bump ubuntu version

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -15,7 +15,7 @@ permissions: read-all
 
 jobs:
   luajit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -10,7 +10,7 @@ permissions: read-all
 
 jobs:
   luajit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -16,7 +16,7 @@ jobs:
 # are covered by fuzzing.
 
   Coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -46,7 +46,7 @@ jobs:
 # code coverage.
 
   Pruning:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -35,7 +35,7 @@ permissions: read-all
 
 jobs:
   luajit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,7 +11,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/oss-fuzz.yml
+++ b/.github/workflows/oss-fuzz.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   lua:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
           - "luajit"
           - "tarantool"
       fail-fast: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,6 +51,7 @@ jobs:
                               cmake \
                               liblzma-dev \
                               libprotobuf-dev \
+                              libreadline-dev \
                               libtool \
                               libz-dev \
                               ninja-build \


### PR DESCRIPTION
Github Actions breaks `check` workflow due to scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15, see [1]. The patch bumps an Ubuntu version in workflows.

1. https://github.com/actions/runner-images/issues/11101