### PR TITLE
tests/capi: fix possible timeout in result chunks

### DIFF
--- a/tests/capi/luaL_loadbuffer_proto/serializer.cc
+++ b/tests/capi/luaL_loadbuffer_proto/serializer.cc
@@ -230,7 +230,7 @@ GetCounterIncrement(const std::string &counter_name)
 	std::string retval = counter_name;
 	retval += " = ";
 	retval += counter_name;
-	retval += " + 1\n";
+	retval += " + 1;\n";
 	return retval;
 }
 
@@ -1209,6 +1209,10 @@ PROTO_TOSTRING(UnaryOperator, op)
 PROTO_TOSTRING(Name, name)
 {
 	std::string ident = ConvertToStringDefault(name.name(), true);
+	/* Prevent using reserved keywords as identifiers. */
+	if (KReservedLuaKeywords.find(ident) != KReservedLuaKeywords.end()) {
+		ident += "_1";
+	}
 	/* Identifier has default name, add an index. */
 	if (!ident.compare(kDefaultIdent)) {
 		ident += std::to_string(name.num() % kMaxIdentifiers);


### PR DESCRIPTION
This patch fixes the Lua inputs in `luaL_loadbuffer_fuzzer` that generate the infinite cycles or recursive function calls, like the following:

```
if counter_0 > 5 then break end
counter_0 = counter_0 + 1
and (0.000000 );
```

The `and` here is generated by the `NameToString()` function, which doesn't check that the name shouldn't be reserved.

This patch adds the corresponding check and separates the counter increment with `;` to avoid any ambiguous syntax.

Follows up the commit 82ec1cc79cf7 ("tests: fix errors "'<name>' expected near 'and'"").

Backported https://github.com/tarantool/tarantool/commit/5836426ccb1e84335d0227a9b8be07e533f5583e