### PR TITLE
tests/capi: fix building luaL_bufflen_test

### DIFF
--- a/tests/capi/luaL_bufflen_test.c
+++ b/tests/capi/luaL_bufflen_test.c
@@ -20,9 +20,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 	if (L == NULL)
 		return 0;
 
-	if (size > LUAI_MAXSTACK)
-		return -1;
-
 	luaL_Buffer buf;
 	char *s = luaL_buffinitsize(L, &buf, size);
 	memcpy(s, data, size);


### PR DESCRIPTION
In the latest commits LUAI_MAXSTACK is defined privately [1]:

> LUAI_MAXSTACK is limited to INT_MAX/2, so can use INT_MAX/2 to
> define pseudo-indices (LUA_REGISTRYINDEX) in 'lua.h'. A change
> in the maximum stack size does not need to change the Lua-C ABI.

1. https://github.com/lua/lua/commit/59a1adf194efe43741c2bb2005d93d8320a19d14