### PR TITLE
cmake: fix ENABLE_LUAJIT_RANDOM_RA option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,7 @@ jobs:
           cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
                 -DUSE_LUAJIT=ON -DENABLE_BUILD_PROTOBUF=OFF \
                 -DENABLE_INTERNAL_TESTS=ON -DENABLE_LAPI_TESTS=ON \
-                -DENABLE_COV=ON \
+                -DENABLE_COV=ON -DENABLE_LUAJIT_RANDOM_RA=ON \
                 -G Ninja -S . -B build
         if: ${{ matrix.LUA == 'luajit' }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,6 @@ set(CMAKE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_INCLUDE_PATH}
 include(SetBuildParallelLevel)
 include(SetHardwareArch)
 
-if (ENABLE_LUAJIT_RANDOM_RA AND NOT IS_LUAJIT)
-  message(FATAL_ERROR "Option ENABLE_LUAJIT_RANDOM_RA is LuaJIT-specific.")
-endif()
-
 if (USE_LUA AND NOT LUA_VERSION)
   set(LUA_VERSION "master")
 endif()
@@ -70,6 +66,10 @@ else ()
 endif ()
 
 message(STATUS "Found ${LUA_VERSION_STRING}")
+
+if (ENABLE_LUAJIT_RANDOM_RA AND NOT IS_LUAJIT)
+  message(FATAL_ERROR "Option ENABLE_LUAJIT_RANDOM_RA is LuaJIT-specific.")
+endif()
 
 if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
    NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
The CMake option ENABLE_LUAJIT_RANDOM_RA has been broken. The patch fixes that and enable this option in testing.