### PR TITLE
patches: reduce PUC Rio Lua patch

### DIFF
--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -89,8 +89,8 @@ macro(build_lua LUA_VERSION)
         PATCH_COMMAND git reset --hard && cd <SOURCE_DIR> && patch -p1 -i ${LUA_PATCH_PATH}
         CONFIGURE_COMMAND ""
         BUILD_COMMAND cd <SOURCE_DIR> && make -j CC=${CMAKE_C_COMPILER}
-                                                 CFLAGS=${CFLAGS}
-                                                 LDFLAGS=${LDFLAGS}
+                                                 MYCFLAGS=${CFLAGS}
+                                                 MYLDFLAGS=${LDFLAGS}
                                                  LF_PATH=${LibFuzzerObjDir}
         INSTALL_COMMAND ""
 

--- a/patches/puc-rio-lua.patch
+++ b/patches/puc-rio-lua.patch
@@ -1,31 +1,7 @@
 diff --git a/makefile b/makefile
-index 8674519f..1773b0eb 100644
+index 8674519f..dd0fb23e 100644
 --- a/makefile
 +++ b/makefile
-@@ -39,7 +39,7 @@ CWARNSC= -Wdeclaration-after-statement \
- 	-Wold-style-definition \
- 
- 
--CWARNS= $(CWARNSCPP) $(CWARNSC) $(CWARNGCC)
-+CWARNS= $(CWARNSCPP) $(CWARNSC)
- 
- # Some useful compiler options for internal tests:
- # -DLUAI_ASSERT turns on all assertions inside Lua.
-@@ -73,11 +73,11 @@ LOCAL = $(TESTS) $(CWARNS)
- # Note that Linux/Posix options are not compatible with C89
- MYCFLAGS= $(LOCAL) -std=c99 -DLUA_USE_LINUX
- MYLDFLAGS= -Wl,-E
--MYLIBS= -ldl
-+MYLIBS= -ldl $(LDFLAGS)
- 
- 
--CC= gcc
--CFLAGS= -Wall -O2 $(MYCFLAGS) -fno-stack-protector -fno-common -march=native
-+CC?= gcc
-+CFLAGS+= -Wall -O2 $(MYCFLAGS) -fno-stack-protector -fno-common -march=native
- AR= ar rc
- RANLIB= ranlib
- RM= rm -f
 @@ -96,9 +96,12 @@ CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
  AUX_O=	lauxlib.o
  LIB_O=	lbaselib.o ldblib.o liolib.o lmathlib.o loslib.o ltablib.o lstrlib.o \


### PR DESCRIPTION
From the beginning, see commit 5868a5f85073446ae0c2b6f93576758b6670f4e8 ("tests: initial commit"), a custom patch for PUC Rio Lua was used. The patch makes it possible passing CFLAGS and LDFLAGS from outside. However, it can be achieved with MYCFLAGS and MYLDFLAGS. This custom patch was often broken by upstream changes (see
acd0cc96467532c4ebdb546c4c1249f1ff96f210 ("patches: fix broken PUC Rio Lua building"), 0bb1334c14466593d539da9fd6782ed09d7f511d ("patches: fix PUC Rio Lua build"), adbbfd0825fb2640d491d760f3a2ce2cec1b1962 ("patches: fix warning on building Lua")) and now the patch is gone.