### PR TITLE
cfl: bump Ubuntu to 24.04

### DIFF
--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,3 +1,4 @@
+base_os_version: ubuntu-24-04
 homepage: "https://luajit.org/"
 language: c
 primary_contact: "estetus@gmail.com"


### PR DESCRIPTION
CFL supports building and running fuzzers in an Ubuntu 24.04 environment, see [1]. The patch bumps Ubuntu version to 24.04.

1. https://google.github.io/oss-fuzz/getting-started/continuous-integration/#ubuntu-2404-support