### PR TITLE
cmake: link with a static libstdc++

### DIFF
--- a/cmake/BuildLua.cmake
+++ b/cmake/BuildLua.cmake
@@ -62,7 +62,7 @@ macro(build_lua LUA_VERSION)
         # `io.popen()` is not supported by default, it is enabled
         # by `LUA_USE_POSIX` flag. Required by a function `random_locale()`.
         AppendFlags(CFLAGS -DLUA_USE_POSIX)
-        AppendFlags(LDFLAGS -lstdc++)
+        AppendFlags(LDFLAGS -static-libstdc++)
     endif()
 
     include(ExternalProject)


### PR DESCRIPTION
Log with error in OSS FUZZ: https://github.com/google/oss-fuzz/actions/runs/29042755981/job/86203730347?pr=15849
The patch tested in PR https://github.com/google/oss-fuzz/pull/15849

----

Running Lua executable in OSS FUZZ environment finished with the following error:

> lua: error while loading shared libraries: libstdc++.so.6: \
>   cannot open shared object file: No such file or directory

The patch fixes that by linking with static libstdc++.

The patch follows up the commit
160691d294beb37955dc1ec3f52b39ec2725b4f0
("cmake: support building on i386").

Follows up #180